### PR TITLE
Monk: Add Monk Kit on main branch

### DIFF
--- a/Dockerfile.static-website
+++ b/Dockerfile.static-website
@@ -1,0 +1,4 @@
+FROM nginx:alpine
+COPY ./index.html /usr/share/nginx/html
+COPY ./images /usr/share/nginx/html/images
+EXPOSE 80

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO beginner-html-site
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,28 @@
+namespace: beginner-html-site
+
+static-website:
+  defines: runnable
+  metadata:
+    name: static-website
+    description: A simple one-page static website for educational purposes
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    static-website:
+      image: env-3257.registry.local/static-website:main-8158340
+      build: .
+      dockerfile: Dockerfile.static-website
+  services:
+    http:
+      description: Standard HTTP port
+      container: static-website
+      port: 80
+      host-port: 80
+      publish: true
+      protocol: tcp
+  connections: {}
+  variables: {}
+
+stack:
+  defines: group
+  members:
+    - beginner-html-site/static-website


### PR DESCRIPTION
# Containerization and Deployment Configuration for Beginner HTML Site

In this PR, I have containerized a simple one-page static website designed to help beginners learn HTML. The repository did not contain any predefined containerization setup such as Dockerfiles or docker-compose files, nor did it require any third-party services like databases.

I created a `Dockerfile.static-website` to serve the static content using Nginx. This Dockerfile uses the `nginx:alpine` base image, copies the `index.html` and `images/` directory to the appropriate location for Nginx, and exposes port 80. The Dockerfile has been tested, and the logs indicate a normal startup sequence for Nginx with no error messages, suggesting that the service is configured correctly.

Additionally, I added a `monk.yaml` file containing the Monk.io configuration and a `MANIFEST` file listing all files containing Monk configurations. There were no environment variables or connections to other services required for this static website, and the standard HTTP port 80 is exposed.

To deploy the application, simply merge this PR, and the application will be re-deployed on each subsequent push. The containerization is complete, and the static website should work correctly when run in a complete environment with all required services and configurations.

### Summary of Changes
- Added `Dockerfile.static-website` for serving the static website with Nginx.
- Added `monk.yaml` for Monk.io deployment configuration.
- Added `MANIFEST` file for Monk.io to recognize configuration files.

The static website is now ready for containerized deployment. No further action is required at this time.